### PR TITLE
Simplify code.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1597,12 +1597,9 @@ fn dump_packets(pkts: &[u8]) -> Result<()> {
                     // same.
                     let t = NaiveDateTime::from_timestamp_opt(
                         d.as_secs() as i64, 0)
-                        .unwrap_or_else(|| {
-                            // This is just compatibility, debugging
-                            // output.  Fallback to the unix epoch.
-                            NaiveDateTime::from_timestamp_opt(0, 0)
-                                .expect("valid")
-                        });
+                        // This is just compatibility, debugging
+                        // output.  Fallback to the unix epoch.
+                        .unwrap_or_default();
                     let t = DateTime::<Utc>::from_utc(t, Utc);
                     output.push(format!("  {}(0x{:08x})",
                                         t.format("%c"),


### PR DESCRIPTION
  - Use `NaiveDateTime::unwrap_or_default` instead of hand coding the Unix Epoch.  It's the same thing, and shorter.

Suggested-by: Nora Widdecke <nora@sequoia-pgp.org>.