### PR TITLE
Add support for setting LIBDIR via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ $ git clone git@github.com:rpm-software-management/rpm-sequoia.git
 Cloning into 'rpm-sequoia'...
 done.
 $ cd rpm-sequoia
-$ PREFIX=/usr cargo build --release && cargo test --release
+$ PREFIX=/usr LIBDIR="\${prefix}/lib64" \
+  cargo build --release && cargo test --release
     Updating crates.io index
 ...
 test result: ok. ...
@@ -96,10 +97,16 @@ cryptographic backends.
 
 The rpm-sequoia artifacts (the .a, .so, and the .pc files) are placed
 in the build directory, which, in this case, is
-`/tmp/rpm/rpm-sequoia/target/release`.  We also set the `PREFIX`
-environment variable when calling `cargo build`.  This is the prefix
-that will be used in the generated `rpm-sequoia.pc` file.  It defaults
-to `/usr/local`.
+`/tmp/rpm/rpm-sequoia/target/release`.
+
+We also set two environment variables when calling `cargo build`:
+
+* `PREFIX` is the prefix that will be used in the generated
+  `rpm-sequoia.pc` file. It defaults to `/usr/local`.
+
+* `LIBDIR` is the installed library path listed in the generated
+  metadata. It can be an absolute path or one based on `${prefix}`,
+  and defaults to `${prefix}/lib`.
 
 
 To run just one or two tests, do something like the following:


### PR DESCRIPTION
Hardcoding the libdir as `${prefix}/lib` isn't correct for systems that keep 64-bit libraries in `${prefix}/lib64`.

Allow setting a variable `LIBDIR` in the environment, to define both the pkg-config libdir and the path passed to cdylib_link_lines().

`LIBDIR` may be an absolute path or one based on `${prefix}`, which will be substituted before creating the PathBuf for cdylib_link_lines.

(Note that the `libdir` argument to cdylib_link_lines is actually only used on macos, so this won't actually have any effect on the linker args emitted on linux. Nevertheless, for the sake of completeness custom `LIBDIR` values based on `${prefix}` are supported.)