### PR TITLE
Add _pgpVerifySignature2

### DIFF
--- a/src/symbols.txt
+++ b/src/symbols.txt
@@ -24,6 +24,7 @@ _pgpDigParamsVersion
 _pgpDigParamsCreationTime
 _pgpDigParamsFree
 _pgpVerifySignature
+_pgpVerifySignature2
 _pgpVerifySig
 _pgpSignatureType
 # Implemented by rpmpgp.c.


### PR DESCRIPTION
  - `_pgpVerifySignature2` is a variant of `_pgpVerifySignature`, which optionally returns a message either describing what wrong, or potential problems (i.e., lints).

  - Fixes #39.