### PR TITLE
Add the sequoia-pgp/authenticate-commits action.

### DIFF
--- a/.github/workflows/authenticate-commits.yml
+++ b/.github/workflows/authenticate-commits.yml
@@ -1,0 +1,16 @@
+name: authenticate-commits
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  authenticate-commits:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Authenticating commits
+        uses: sequoia-pgp/authenticate-commits@v1


### PR DESCRIPTION
  - Add the `sequoia-pgp/authenticate-commits` action to check that pull requests are authorized according to the signing policy.