### PR TITLE
Don't eagerly reject expired or revoked certificates.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1672,7 +1672,6 @@ fn _pgpPubKeyLint(pkts: *const c_char,
                                   unspecified reason");
                         }
                     }
-                    break 'done false;
                 }
 
                 if let Err(err) = vc.alive() {
@@ -1685,7 +1684,6 @@ fn _pgpPubKeyLint(pkts: *const c_char,
                                           err));
                         }
                     }
-                    break 'done false;
                 }
             }
         };


### PR DESCRIPTION
  - Even if a certificate is expired or revoked, it doesn't mean that it is completely useless.  If a signature was made before the certificate expired, or before any soft revocation, then it may still be valid.

  - This is safe, because we still check that a certificate is valid when we check a signature.

  - Fixes #59.