### PR TITLE
Look for symbols in opd section

### DIFF
--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -39,6 +39,7 @@ fn symbols() -> anyhow::Result<()> {
     for line in output.split("\n") {
         if line.contains("g    DF .text")
             || line.contains("g    DO .data")
+            || line.contains("g    DF .opd")
         {
             let symbol = line.split(' ').last().expect("a word");
             symbols.push(symbol);


### PR DESCRIPTION
This patch fixes test case for ppc64.
ppc64 binary has function symbols in opd section, which current test case does not expect.

<details><summary>test log</summary>

```
     Running `/var/tmp/portage/app-crypt/rpm-sequoia-1.6.0/work/rpm-sequoia-1.6.0/target/release/deps/symbols-3405ed49d96325fa`

running 1 test
test symbols ... FAILED

failures:

---- symbols stdout ----
Found 0 symbols:
Expected 33 symbols:
  _pgpArmorWrap
  _pgpCleanDig
  _pgpDigGetParams
  _pgpDigParamsAlgo
  _pgpDigParamsCmp
  _pgpDigParamsCreationTime
  _pgpDigParamsFree
  _pgpDigParamsSignID
  _pgpDigParamsUserID
  _pgpDigParamsVersion
  _pgpFreeDig
  _pgpNewDig
  _pgpParsePkts
  _pgpPrtParams
  _pgpPrtParams2
  _pgpPrtParamsSubkeys
  _pgpPrtPkts
  _pgpPubKeyCertLen
  _pgpPubKeyLint
  _pgpPubkeyFingerprint
  _pgpPubkeyKeyID
  _pgpSignatureType
  _pgpVerifySig
  _pgpVerifySignature
  _pgpVerifySignature2
  _rpmDigestDup
  _rpmDigestFinal
  _rpmDigestInit
  _rpmDigestLength
  _rpmDigestUpdate
  _rpmFreeCrypto
  _rpmInitCrypto
  rust_eh_personality (optional)
Missing expected symbol _pgpArmorWrap
Missing expected symbol _pgpCleanDig
Missing expected symbol _pgpDigGetParams
Missing expected symbol _pgpDigParamsAlgo
Missing expected symbol _pgpDigParamsCmp
Missing expected symbol _pgpDigParamsCreationTime
Missing expected symbol _pgpDigParamsFree
Missing expected symbol _pgpDigParamsSignID
Missing expected symbol _pgpDigParamsUserID
Missing expected symbol _pgpDigParamsVersion
Missing expected symbol _pgpFreeDig
Missing expected symbol _pgpNewDig
Missing expected symbol _pgpParsePkts
Missing expected symbol _pgpPrtParams
Missing expected symbol _pgpPrtParams2
Missing expected symbol _pgpPrtParamsSubkeys
Missing expected symbol _pgpPrtPkts
Missing expected symbol _pgpPubKeyCertLen
Missing expected symbol _pgpPubKeyLint
Missing expected symbol _pgpPubkeyFingerprint
Missing expected symbol _pgpPubkeyKeyID
Missing expected symbol _pgpSignatureType
Missing expected symbol _pgpVerifySig
Missing expected symbol _pgpVerifySignature
Missing expected symbol _pgpVerifySignature2
Missing expected symbol _rpmDigestDup
Missing expected symbol _rpmDigestFinal
Missing expected symbol _rpmDigestInit
Missing expected symbol _rpmDigestLength
Missing expected symbol _rpmDigestUpdate
Missing expected symbol _rpmFreeCrypto
Missing expected symbol _rpmInitCrypto
*** If you see unexpected symbols like SHA1DCInit..., then you need version 0.2.6 or later of sha1collisiondetection. ***
Error: symbol mismatch


failures:
    symbols

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

error: test failed, to rerun pass `--test symbols`
```

</details>

<details><summary>binary info</summary>

```
# file /usr/lib64/librpm_sequoia.so.1 
/usr/lib64/librpm_sequoia.so.1: ELF 64-bit MSB shared object, 64-bit PowerPC or cisco 7500, Power ELF V1 ABI, version 1 (SYSV), dynamically linked, stripped

# objdump -T /usr/lib64/librpm_sequoia.so.1 | grep 'DF .opd'
0000000000585440 g    DF .opd	00000000000005fc  Base        _rpmInitCrypto
0000000000585650 g    DF .opd	0000000000000620  Base        _pgpPubkeyKeyID
0000000000585710 g    DF .opd	0000000000000630  Base        _pgpPrtParams
00000000005855f0 g    DF .opd	000000000000062c  Base        _pgpVerifySignature
0000000000587468 g    DF .opd	0000000000000634  Base        _rpmDigestUpdate
0000000000585590 g    DF .opd	000000000000061c  Base        _pgpDigParamsVersion
0000000000587450 g    DF .opd	0000000000000614  Base        _rpmDigestLength
00000000005857d0 g    DF .opd	0000000000000624  Base        _pgpPubKeyLint
0000000000585908 g    DF .opd	000000000000060c  Base        _pgpVerifySig
00000000005854b8 g    DF .opd	0000000000000604  Base        _pgpDigParamsFree
00000000005856b0 g    DF .opd	0000000000000624  Base        _pgpArmorWrap
0000000000585878 g    DF .opd	00000000000005f8  Base        _pgpCleanDig
0000000000585848 g    DF .opd	00000000000005ec  Base        _pgpNewDig
0000000000585620 g    DF .opd	0000000000000648  Base        _pgpVerifySignature2
0000000000585740 g    DF .opd	000000000000063c  Base        _pgpPrtParams2
0000000000585530 g    DF .opd	000000000000060c  Base        _pgpDigParamsSignID
00000000005856e0 g    DF .opd	0000000000000628  Base        _pgpPubKeyCertLen
0000000000587498 g    DF .opd	0000000000000638  Base        _rpmDigestFinal
0000000000585500 g    DF .opd	0000000000000610  Base        _pgpDigParamsAlgo
0000000000585818 g    DF .opd	0000000000000620  Base        _pgpPrtPkts
00000000005857a0 g    DF .opd	0000000000000624  Base        _pgpParsePkts
00000000005858d8 g    DF .opd	0000000000000610  Base        _pgpDigGetParams
0000000000585560 g    DF .opd	000000000000060c  Base        _pgpDigParamsUserID
0000000000587420 g    DF .opd	0000000000000610  Base        _rpmDigestDup
00000000005855c0 g    DF .opd	0000000000000620  Base        _pgpDigParamsCreationTime
00000000005854d0 g    DF .opd	0000000000000610  Base        _pgpDigParamsCmp
0000000000585488 g    DF .opd	0000000000000608  Base        _pgpSignatureType
0000000000585470 g    DF .opd	00000000000005fc  Base        _rpmFreeCrypto
0000000000585680 g    DF .opd	0000000000000648  Base        _pgpPubkeyFingerprint
0000000000585770 g    DF .opd	0000000000000654  Base        _pgpPrtParamsSubkeys
00000000005858a8 g    DF .opd	00000000000005fc  Base        _pgpFreeDig
00000000005873f0 g    DF .opd	0000000000000618  Base        _rpmDigestInit
```

</details>

Gentoo Bug: https://bugs.gentoo.org/933486