### PR TITLE
Port to sequoia-openpgp 2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "nettle-sys"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b495053a10a19a80e3a26bf1212e92e29350797b5f5bdc58268c3f3f818e66ec"
+checksum = "61a3f5406064d310d59b1a219d3c5c9a49caf4047b6496032e3f930876488c34"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,11 +240,10 @@ dependencies = [
 
 [[package]]
 name = "buffered-reader"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd098763fdb64579407a8c83cf0d751e6d4a7e161d0114c89cc181a2ca760ec8"
+checksum = "db26bf1f092fd5e05b5ab3be2f290915aeb6f3f20c4e9f86ce0f07f336c2412f"
 dependencies = [
- "lazy_static",
  "libc",
 ]
 
@@ -926,14 +946,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
- "smallvec",
- "utf8_iter",
 ]
 
 [[package]]
@@ -972,6 +1001,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1198,6 +1236,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1356,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -1650,13 +1711,14 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "sequoia-openpgp"
-version = "1.21.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b870b0275eeae174058fcf0ce5affccaaafeb7eceeabce8d6c7f51fbe6a41e2a"
+checksum = "015e5fc3d023418b9db98ca9a7f3e90b305872eeafe5ca45c5c32b5eb335c1e8"
 dependencies = [
  "aes",
  "aes-gcm",
  "anyhow",
+ "argon2",
  "base64",
  "block-padding",
  "blowfish",
@@ -1677,17 +1739,17 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "getrandom",
+ "hkdf",
  "idea",
  "idna",
  "lalrpop",
  "lalrpop-util",
- "lazy_static",
  "libc",
  "md-5",
  "memsec",
  "nettle",
  "num-bigint-dig",
- "once_cell",
+ "ocb3",
  "openssl",
  "openssl-sys",
  "p256",
@@ -1701,6 +1763,7 @@ dependencies = [
  "rsa",
  "sha1collisiondetection",
  "sha2",
+ "sha3",
  "thiserror",
  "twofish",
  "typenum",
@@ -1712,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "sequoia-policy-config"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757d45d308f2bd9c0d6fdd640f320998ad24856bdf2890ddd28d3c3b85808274"
+checksum = "8e016b708d64857b6a97e1a331d9471b73e30ed450d247628e1a0ce236b1e597"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1764,6 +1827,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,6 @@ version = "1.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "buffered-reader",
  "cdylib-link-lines",
  "chrono",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anyhow = "1"
-buffered-reader = { version = "1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = [ "std" ] }
 lazy_static = "1"
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = [ "std" ] }
 lazy_static = "1"
 libc = "0.2"
-sequoia-openpgp = { version = "1.21.1", default-features = false }
-sequoia-policy-config = "0.6"
+sequoia-openpgp = { version = "2", default-features = false }
+sequoia-policy-config = "0.8"
 thiserror = "1"
 
 [build-dependencies]

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -7,15 +7,14 @@ use libc::{
 };
 
 use sequoia_openpgp as openpgp;
-use openpgp::types::HashAlgorithm;
-use openpgp::crypto::hash::Digest;
+use openpgp::crypto::{HashAlgorithm, hash};
 
 use crate::Error;
 use crate::Result;
 
 #[derive(Clone)]
 pub struct DigestContext {
-    pub(crate) ctx: Box<dyn Digest>,
+    pub(crate) ctx: hash::Context,
 }
 
 impl DigestContext {
@@ -51,7 +50,7 @@ fn _rpmDigestInit(hashalgo: c_int, flags: c_int) -> *mut DigestContext {
     }
 
     let ctx = DigestContext {
-        ctx: hashalgo.context()?,
+        ctx: hashalgo.context()?.for_digest(),
     };
 
     Ok(move_to_c!(ctx))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ use openpgp::policy::{
 use openpgp::serialize::SerializeInto;
 use openpgp::types::RevocationStatus;
 
+use openpgp::parse::buffered_reader;
+
 #[macro_use] mod log;
 #[macro_use] mod ffi;
 #[macro_use] pub mod rpm;

--- a/src/rpm.rs
+++ b/src/rpm.rs
@@ -186,6 +186,7 @@ impl From<Option<armor::Kind>> for PgpArmor {
             Some(SecretKey) => PgpArmor::Seckey, // XXX: PgpArmor::Privkey
             Some(Signature) => PgpArmor::Signature, // XXX: PgpArmor::SignedMessage
             Some(File) => PgpArmor::File,
+            _ => PgpArmor::File, // XXX
         }
     }
 }

--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -8,6 +8,9 @@ use assert_cmd::assert::OutputAssertExt;
 
 #[test]
 fn symbols() -> anyhow::Result<()> {
+    // Make sure the library is built.
+    Command::new("cargo").arg("build").ok()?;
+
     // We want the location of the build directory (e.g.,
     // `/tmp/rpm-sequoia/debug`).
     //


### PR DESCRIPTION
I think this looks fairly good, let's see what the ci says.

One thing to sort out is how to map the armor::Kind catchall to
PgpArmor, see the change to src/rpm.rs.

Note that this may or may not mean that rpm-sequoia supports
    RFC9580, depending on what low-level things rpm-sequoia does, or
    maybe what the interface to RPM assumes (like fingerprint lengths,
    algorithms, etc.).