### PR TITLE
Use optional env vars to force runtime paths in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,11 @@ $ make check
 To run the symbols test binary without having a Rust toolchain installed, set an environment 
 variable called `TEST_DONT_BUILD_LIB` with any value. This of course requires you to build 
 the library before the test would be executed.
+
+# Cross Compiling
+
+In a cross-compilation context (e.g., Yocto), Cargo's default paths
+(`OUT_DIR` and `CARGO_MANIFEST_DIR`) may not be valid when the test
+suite is run.  To run the test suite anyway, you can set
+`FORCE_RUNTIME_PATH_LIB` and `FORCE_RUNTIME_PATH_SRC` to override
+these paths.

--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -20,7 +20,8 @@ fn symbols() -> anyhow::Result<()> {
     // OUT_DIR gives us
     // `/tmp/rpm-sequoia/debug/build/rpm-sequoia-HASH/out`.
 
-    let out_dir = PathBuf::from(env!("OUT_DIR"));
+    let out_dir = PathBuf::from(option_env!("FORCE_RUNTIME_PATH_LIB")
+        .unwrap_or(env!("OUT_DIR")));
     let mut build_dir = out_dir;
     let lib = loop {
         let mut lib = build_dir.clone();
@@ -59,7 +60,8 @@ fn symbols() -> anyhow::Result<()> {
     }
 
     let mut expected_symbols_txt_fn
-        = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        = PathBuf::from(option_env!("FORCE_RUNTIME_PATH_SRC")
+            .unwrap_or(env!("CARGO_MANIFEST_DIR")));
     expected_symbols_txt_fn.push("src/symbols.txt");
 
     let mut expected_symbols_txt = Vec::new();


### PR DESCRIPTION
In a cross-compilation context (e.g., Yocto), Cargo's default paths (OUT_DIR , CARGO_MANIFEST_DIR) are invalid at runtime. To fix this, we use FORCE_RUNTIME_PATH_LIB and FORCE_RUNTIME_PATH_SRC in the code test symbols.rs 
to override these paths when set.
This ensures compatibility while keeping the default behavior for local Cargo builds.