### PR TITLE
Allow RPM to get signature salt for OpenPGP v6 signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,17 +136,19 @@ jobs:
 
              echo "::group::make check"
              cd rpm
-             # enable sha3 test in rpm testsuite
+             # enable new test in rpm testsuite and patch dockerfile
              patch -p1 < ../tests/rpm.patch
              RPM_ROOT=$(pwd)
+             # copy the rpm-sequoia artifacts to rpm directory
+             mkdir sequoia
+             cp ../target/debug/librpm_sequoia.so* sequoia/
+             cp ../target/debug/rpm-sequoia.pc sequoia/
              cd tests
              # based on ./mktree.oci build
-             podman build --target full -t rpm-tests -f Dockerfile ..
-             # install rpm-sequoia in the test image
-             podman build -t rpm-tests-sequoia -f ../../tests/Dockerfile ../../
-             # run the tests by overriding librpm-sequoia in the container.
+             podman build --target full -t rpm-tests -f Dockerfile $RPM_ROOT
+             # run the tests with new sequoia
              if ! podman run --privileged -it --rm --read-only --tmpfs /tmp -v $RPM_ROOT:/srv:z \
-                --workdir /srv -e ROOTLESS=1 rpm-tests-sequoia \
+                --workdir /srv -e ROOTLESS=1 rpm-tests \
                 rpmtests -k OpenPGP -k signature -k rpmkeys -k digest;
              then
                  echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
 
              echo "::group::make check"
              cd rpm
+             # enable sha3 test in rpm testsuite
+             patch -p1 < ../tests/rpm.patch
              RPM_ROOT=$(pwd)
              cd tests
              # based on ./mktree.oci build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup | Dependencies
         run: sudo apt update && sudo apt install codespell
       - name: Codespell
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup | Build Cache rpm-sequoia
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -55,12 +55,12 @@ jobs:
     needs: ["Compile"]
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup | Build Cache rpm-sequoia
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -85,12 +85,12 @@ jobs:
     needs: ["Compile"]
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup | Build Cache rpm-sequoia
-        uses: actions/cache@v3
+      - name: Setup | Build Cache Rust dependencies
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -107,23 +107,16 @@ jobs:
         run: cargo build
 
       - name: Setup | rpm Dependencies
-        run: sudo apt install automake autoconf autopoint gettext libtool tar zlib1g-dev libpopt-dev libsqlite3-dev liblua5.4-dev fakechroot libarchive-dev libmagic-dev
+        run: |
+          sudo apt install podman
 
       - name: Setup | Checkout rpm
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: rpm-software-management/rpm.git
-          ref: rpm-4.18.x
+          ref: master
           fetch-depth: 1
-          path: rpm-pristine
-
-      - name: Setup | Build Cache rpm
-        uses: actions/cache@v3
-        with:
-          path: |
-            rpm/
-            rpm-build/
-          key: ${{ runner.os }}-rpm-${{ hashFiles('rpm-pristine/.git/HEAD', 'rpm-pristine/.git/refs/heads/master') }}
+          path: rpm
 
       - name: Test | rpm
         run: |
@@ -141,36 +134,22 @@ jobs:
                  exit 1
              fi
 
-             echo "::group::configure"
-
-             # If rpm doesn't exist, then we don't have a cache of an
-             # rpm build.
-             if ! test -e rpm
-             then
-                 cp -a rpm-pristine rpm
-
-                 cd rpm
-                 autoreconf -is
-                 cd ..
-
-                 mkdir -p rpm-build
-                 cd rpm-build
-                 ../rpm/configure --prefix=/ --with-crypto=sequoia
-             else
-                 cd rpm-build
-             fi
-             echo "::endgroup::"
-
-             echo "::group::make"
-             make
-             echo "::endgroup::"
-
              echo "::group::make check"
+             cd rpm
+             RPM_ROOT=$(pwd)
              cd tests
-             if ! make check TESTSUITEFLAGS="-k OpenPGP -k signature -k rpmkeys -k digest"
+             # based on ./mktree.oci build
+             podman build --target full -t rpm-tests -f Dockerfile ..
+             # install rpm-sequoia in the test image
+             podman build -t rpm-tests-sequoia -f ../../tests/Dockerfile ../../
+             # run the tests by overriding librpm-sequoia in the container.
+             if ! podman run --privileged -it --rm --read-only --tmpfs /tmp -v $RPM_ROOT:/srv:z \
+                --workdir /srv -e ROOTLESS=1 rpm-tests-sequoia \
+                rpmtests -k OpenPGP -k signature -k rpmkeys -k digest;
              then
                  echo "::endgroup::"
 
+                 cd ..
                  for log in rpmtests.dir/*/rpmtests.log
                  do
                      echo "::group::$log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Setup | Checkout rpm
         uses: actions/checkout@v4
         with:
-          repository: rpm-software-management/rpm.git
-          ref: master
+          repository: pmatilai/rpm.git
+          ref: v6salt
           fetch-depth: 1
           path: rpm
 

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -80,6 +80,8 @@ fn _rpmDigestLength(hashalgo: c_int) -> size_t[0] {
         SHA384 => 48,
         SHA512 => 64,
         SHA224 => 28,
+        SHA3_256 => 32,
+        SHA3_512 => 64,
         _ => 0,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,13 +932,18 @@ fn pgp_verify_signature(key: Option<&PgpDigParams>,
 
         // Hash the signature into the context.
         match sig.version() {
-            4 => {
+            4 | 6 => {
                 sig_data.push(sig.version());
                 sig_data.push(sig.typ().into());
                 sig_data.push(sig.pk_algo().into());
                 sig_data.push(sig.hash_algo().into());
 
-                let l = sig.hashed_area().serialized_len() as u16;
+                let l = sig.hashed_area().serialized_len();
+                if sig.version() == 6 {
+                    // The v6 signatures encode the hashed length as 4 bytes
+                    sig_data.push((l >> 24) as u8);
+                    sig_data.push((l >> 16) as u8);
+                }
                 sig_data.push((l >> 8) as u8);
                 sig_data.push((l >> 0) as u8);
 

--- a/src/symbols.txt
+++ b/src/symbols.txt
@@ -23,6 +23,7 @@ _pgpDigParamsSignID
 _pgpDigParamsUserID
 _pgpDigParamsVersion
 _pgpDigParamsCreationTime
+_pgpDigParamsSalt
 _pgpDigParamsFree
 _pgpPubkeyMerge
 _pgpVerifySignature

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,7 @@
+FROM rpm-tests as src
+MAINTAINER jakuje@gmail.com
+
+WORKDIR /srv/rpm
+COPY /target/debug/librpm_sequoia.so /usr/local/lib64/
+COPY /target/debug/librpm_sequoia.so.1 /usr/local/lib64/
+RUN ldconfig

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,0 @@
-FROM rpm-tests as src
-MAINTAINER jakuje@gmail.com
-
-WORKDIR /srv/rpm
-COPY /target/debug/librpm_sequoia.so /usr/local/lib64/
-COPY /target/debug/librpm_sequoia.so.1 /usr/local/lib64/
-RUN ldconfig

--- a/tests/rpm.patch
+++ b/tests/rpm.patch
@@ -1,0 +1,12 @@
+diff --git a/tests/rpmbuild.at b/tests/rpmbuild.at
+index 68e63c862..d4166fedb 100644
+--- a/tests/rpmbuild.at
++++ b/tests/rpmbuild.at
+@@ -3887,7 +3887,6 @@ RPMTEST_CLEANUP
+ 
+ RPMTEST_SETUP_RW([file digests sha3])
+ AT_KEYWORDS([build digest])
+-RPMTEST_SKIP_IF([test x$PGP = xsequoia])
+ RPMTEST_CHECK([[
+ runroot rpmbuild -bs --quiet \
+ 		--define "_source_filedigest_algorithm 12" \

--- a/tests/rpm.patch
+++ b/tests/rpm.patch
@@ -10,3 +10,73 @@ index 68e63c862..d4166fedb 100644
  RPMTEST_CHECK([[
  runroot rpmbuild -bs --quiet \
  		--define "_source_filedigest_algorithm 12" \
+diff --git a/tests/rpmsigdig.at b/tests/rpmsigdig.at
+index d0154aeec..ec224593d 100644
+--- a/tests/rpmsigdig.at
++++ b/tests/rpmsigdig.at
+@@ -2402,20 +2402,20 @@ runroot rpmsign --addsign --rpmv6 /tmp/hello-2.0-1.x86_64.rpm
+ # In addition, rpm-sequoia 1.8 doesn't handle the v6 trailer so it's BAD
+ # instead of NOKEY.
+ # Header OpenPGP V6 Ed25519/SHA512 signature, key ID 0e00df3ed2d7b65e: BAD
+-#RPMTEST_CHECK([
+-#runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+-#],
+-#[0],
+-#[/tmp/hello-2.0-1.x86_64.rpm:
+-#    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
+-#    Header OpenPGP RSA signature: NOTFOUND
+-#    Header OpenPGP DSA signature: NOTFOUND
+-#    Header SHA256 digest: OK
+-#    Payload SHA256 digest: OK
+-#    Legacy OpenPGP RSA signature: NOTFOUND
+-#    Legacy OpenPGP DSA signature: NOTFOUND
+-#],
+-#[])
++RPMTEST_CHECK([
++runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
++],
++[1],
++[/tmp/hello-2.0-1.x86_64.rpm:
++    Header OpenPGP V6 Ed25519/SHA512 signature, key ID 6118abe481c41473: NOKEY
++    Header OpenPGP RSA signature: NOTFOUND
++    Header OpenPGP DSA signature: NOTFOUND
++    Header SHA256 digest: OK
++    Payload SHA256 digest: OK
++    Legacy OpenPGP RSA signature: NOTFOUND
++    Legacy OpenPGP DSA signature: NOTFOUND
++],
++[])
+ 
+ RPMTEST_CHECK([
+ runroot rpmkeys --import /data/keys/rpm.org-v6-ed25519-test.asc
+@@ -2433,20 +2433,16 @@ runroot rpmkeys --list 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03
+ [])
+ 
+ # This is currently failing, see the NOKEY case above
+-#RPMTEST_CHECK([
+-#runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
+-#],
+-#[0],
+-#[/tmp/hello-2.0-1.x86_64.rpm:
+-#    Header OpenPGP V6 Ed25519/SHA512 signature, key fingerprint 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3 OK
+-#    Header OpenPGP RSA signature: NOTFOUND
+-#    Header OpenPGP DSA signature: NOTFOUND
+-#    Header SHA256 digest: OK
+-#    Payload SHA256 digest: OK
+-#    Legacy OpenPGP RSA signature: NOTFOUND
+-#    Legacy OpenPGP DSA signature: NOTFOUND
+-#],
+-#[])
++RPMTEST_CHECK([
++runroot rpmkeys -Kv /tmp/hello-2.0-1.x86_64.rpm
++],
++[0],
++[/tmp/hello-2.0-1.x86_64.rpm:
++    Header OpenPGP V6 Ed25519/SHA512 signature, key fingerprint: 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3: OK
++    Header SHA256 digest: OK
++    Payload SHA256 digest: OK
++],
++[])
+ 
+ RPMTEST_CHECK([
+ runroot rpmkeys --delete 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3

--- a/tests/rpm.patch
+++ b/tests/rpm.patch
@@ -80,3 +80,19 @@ index d0154aeec..ec224593d 100644
  
  RPMTEST_CHECK([
  runroot rpmkeys --delete 036824f0ac60aed6f1a3256f88190469f6d7255e3d8e41c577233aa03e0bb9d3
+diff --git a/tests/Dockerfile.fedora b/tests/Dockerfile.fedora
+index 8fc61ba2b..8ad879234 100644
+--- a/tests/Dockerfile.fedora
++++ b/tests/Dockerfile.fedora
+@@ -82,6 +82,10 @@ FROM base AS full
+ 
+ WORKDIR /srv/rpm
+ COPY . .
++COPY /sequoia/librpm_sequoia.so /usr/local/lib64/
++COPY /sequoia/librpm_sequoia.so.1 /usr/local/lib64/
++COPY /sequoia/rpm-sequoia.pc /usr/local/lib64/pkgconfig/
++RUN ldconfig
+ 
+ WORKDIR /srv/build
+ ENV CFLAGS="-Og -g"
+


### PR DESCRIPTION
Most of the content is the same as in #91, but attempts to address the hashing issue using the new API for RPM.