### PR TITLE
Allow RPM to get signature salt for OpenPGP v6 signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup | Dependencies
         run: sudo apt update && sudo apt install codespell
       - name: Codespell
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup | Build Cache rpm-sequoia
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -55,12 +55,12 @@ jobs:
     needs: ["Compile"]
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup | Build Cache rpm-sequoia
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -85,12 +85,12 @@ jobs:
     needs: ["Compile"]
     steps:
       - name: Setup | Checkout rpm-sequoia
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup | Build Cache rpm-sequoia
-        uses: actions/cache@v3
+      - name: Setup | Build Cache Rust dependencies
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -107,23 +107,16 @@ jobs:
         run: cargo build
 
       - name: Setup | rpm Dependencies
-        run: sudo apt install automake autoconf autopoint gettext libtool tar zlib1g-dev libpopt-dev libsqlite3-dev liblua5.4-dev fakechroot libarchive-dev libmagic-dev
+        run: |
+          sudo apt install podman
 
       - name: Setup | Checkout rpm
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: rpm-software-management/rpm.git
-          ref: rpm-4.18.x
+          ref: master
           fetch-depth: 1
-          path: rpm-pristine
-
-      - name: Setup | Build Cache rpm
-        uses: actions/cache@v3
-        with:
-          path: |
-            rpm/
-            rpm-build/
-          key: ${{ runner.os }}-rpm-${{ hashFiles('rpm-pristine/.git/HEAD', 'rpm-pristine/.git/refs/heads/master') }}
+          path: rpm
 
       - name: Test | rpm
         run: |
@@ -141,36 +134,22 @@ jobs:
                  exit 1
              fi
 
-             echo "::group::configure"
-
-             # If rpm doesn't exist, then we don't have a cache of an
-             # rpm build.
-             if ! test -e rpm
-             then
-                 cp -a rpm-pristine rpm
-
-                 cd rpm
-                 autoreconf -is
-                 cd ..
-
-                 mkdir -p rpm-build
-                 cd rpm-build
-                 ../rpm/configure --prefix=/ --with-crypto=sequoia
-             else
-                 cd rpm-build
-             fi
-             echo "::endgroup::"
-
-             echo "::group::make"
-             make
-             echo "::endgroup::"
-
              echo "::group::make check"
+             cd rpm
+             RPM_ROOT=$(pwd)
              cd tests
-             if ! make check TESTSUITEFLAGS="-k OpenPGP -k signature -k rpmkeys -k digest"
+             # based on ./mktree.oci build
+             podman build --target full -t rpm-tests -f Dockerfile ..
+             # install rpm-sequoia in the test image
+             podman build -t rpm-tests-sequoia -f ../../tests/Dockerfile ../../
+             # run the tests by overriding librpm-sequoia in the container.
+             if ! podman run --privileged -it --rm --read-only --tmpfs /tmp -v $RPM_ROOT:/srv:z \
+                --workdir /srv -e ROOTLESS=1 rpm-tests-sequoia \
+                rpmtests -k OpenPGP -k signature -k rpmkeys -k digest;
              then
                  echo "::endgroup::"
 
+                 cd ..
                  for log in rpmtests.dir/*/rpmtests.log
                  do
                      echo "::group::$log"

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -80,6 +80,8 @@ fn _rpmDigestLength(hashalgo: c_int) -> size_t[0] {
         SHA384 => 48,
         SHA512 => 64,
         SHA224 => 28,
+        SHA3_256 => 32,
+        SHA3_512 => 64,
         _ => 0,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,6 +591,43 @@ fn _pgpDigParamsCreationTime(dig: *const PgpDigParams) -> u32[0] {
 });
 
 ffi!(
+/// Returns a signature's salt.
+///
+/// Version 6 signatures are salted.  The salt needs to be fed into
+/// the digest buffer before the actual message, which is processed
+/// already by RPM.
+///
+/// The caller must *not* free the returned buffer.
+///
+/// Returns an error if the signature does not include a salt.
+/// Version 6 signatures always have a salt; version 3 and version 4
+/// signatures never have a salt and thus will always return an error.
+fn _pgpDigParamsSalt(dig: *const PgpDigParams,
+                     datap: *mut *const u8,
+                     lenp: *mut size_t)
+    -> ErrorCode
+{
+    let dig = check_ptr!(dig);
+    let datap = check_mut!(datap);
+    let lenp = check_mut!(lenp);
+
+    let sig = dig.signature().ok_or_else(|| {
+        Error::Fail("sig parameter does not designate a signature".into())
+    })?;
+
+    if let Some(salt) = sig.salt() {
+        t!("Salt: {}",
+           salt.iter().map(|v| format!("{:02X}", v)).collect::<String>());
+        *lenp = salt.len() as size_t;
+        *datap = salt.as_ptr();
+        Ok(())
+    } else {
+        Err(Error::Fail("The provided signature does not have any salt".into()))
+    }
+});
+
+
+ffi!(
 /// Verifies the signature.
 ///
 /// If `key` is `NULL`, then this computes the hash and checks it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,13 +932,18 @@ fn pgp_verify_signature(key: Option<&PgpDigParams>,
 
         // Hash the signature into the context.
         match sig.version() {
-            4 => {
+            4 | 6 => {
                 sig_data.push(sig.version());
                 sig_data.push(sig.typ().into());
                 sig_data.push(sig.pk_algo().into());
                 sig_data.push(sig.hash_algo().into());
 
-                let l = sig.hashed_area().serialized_len() as u16;
+                let l = sig.hashed_area().serialized_len();
+                if sig.version() == 6 {
+                    // The v6 signatures encode the hashed length as 4 bytes
+                    sig_data.push((l >> 24) as u8);
+                    sig_data.push((l >> 16) as u8);
+                }
                 sig_data.push((l >> 8) as u8);
                 sig_data.push((l >> 0) as u8);
 

--- a/src/symbols.txt
+++ b/src/symbols.txt
@@ -23,6 +23,7 @@ _pgpDigParamsSignID
 _pgpDigParamsUserID
 _pgpDigParamsVersion
 _pgpDigParamsCreationTime
+_pgpDigParamsSalt
 _pgpDigParamsFree
 _pgpPubkeyMerge
 _pgpVerifySignature

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,7 @@
+FROM rpm-tests as src
+MAINTAINER jakuje@gmail.com
+
+WORKDIR /srv/rpm
+COPY /target/debug/librpm_sequoia.so /usr/local/lib64/
+COPY /target/debug/librpm_sequoia.so.1 /usr/local/lib64/
+RUN ldconfig


### PR DESCRIPTION
This is a variant of https://github.com/rpm-software-management/rpm-sequoia/pull/92 .  It fixes a few issues in the README, and includes several minor clean ups (I did them directly to save you time, @Jakuje).  I also dropped the patches for the unreleased version of RPM.  As such once the relevant parts are merged, we should automatically start testing the new functionality via its test suite.