### PR TITLE
tests: build lib for symbols tests conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,9 @@ $ ../configure --prefix=/ --with-crypto=sequoia
 $ make
 $ make check
 ```
+
+# Symbols test without Rust toolchain
+
+To run the symbols test binary without having a Rust toolchain installed, set an environment 
+variable called `TEST_DONT_BUILD_LIB` with any value. This of course requires you to build 
+the library before the test would be executed.

--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -9,7 +9,10 @@ use assert_cmd::assert::OutputAssertExt;
 #[test]
 fn symbols() -> anyhow::Result<()> {
     // Make sure the library is built.
-    Command::new("cargo").arg("build").ok()?;
+    let skip_build_library = env::var("TEST_DONT_BUILD_LIB").is_ok();
+    if ! skip_build_library {
+        Command::new("cargo").arg("build").ok()?;
+    }
 
     // We want the location of the build directory (e.g.,
     // `/tmp/rpm-sequoia/debug`).


### PR DESCRIPTION
When the tests are executed, cargo might not be available, however the library could be built already.

An example of when this could happen is cross-compiling for embedded systems: when the library is compiled for a different (potentially low powered) system, then at runtime frequently there is no rust toolchain available to build the library; however the library is usually already built and installed.

To be able to run the test on pre-built artifacts, introduce an environment variable, `TEST_DONT_BUILD_LIB`, which, if present with any value, will skip building the library, thus allow running the tests without having a Rust toolchain installed.

(This is of course only one possible solution... I'd be interested in alternatives also)