### PR TITLE
Be more careful when copying a key ID to a buffer.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,7 +989,10 @@ fn pgp_verify_signature(key: Option<&PgpDigParams>,
                 sig_data.push((l >> 8) as u8);
                 sig_data.push((l >> 0) as u8);
 
-                sig.hashed_area().serialize(&mut sig_data).expect("vec");
+                if let Err(err) = sig.hashed_area().serialize(&mut sig_data) {
+                    return Err(Error::Fail(
+                        format!("Hashing signature data: {}", err)));
+                }
 
                 let sig_len = sig_data.len();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1559,9 +1559,16 @@ fn pgp_prt_params(pkts: *const u8, pktlen: size_t,
     };
 
     let mut buffer: [u8; 8] = [0; 8];
-    if let Some(issuer) = issuer {
-        for (i, c) in issuer.as_bytes().into_iter().enumerate() {
-            buffer[i] = *c as u8;
+    match issuer {
+        Some(KeyID::Long(issuer)) => {
+            assert_eq!(buffer.len(), issuer.len());
+            buffer.copy_from_slice(&issuer);
+        }
+        issuer => {
+            return_err!(
+                None,
+                "Signature contains an invalid issuer packet: {:?}",
+                issuer);
         }
     }
 


### PR DESCRIPTION
Normally, an issuer subpacket is 8 bytes long.  An attacker could
craft a signature that contains a longer issuer subpacket.  When
copying the value of such an issuer subpacket, Rust would detect an
out-of-bounds access, and panic.

Fix it by rejecting signatures with invalid issuer subpackets.

Fixes: CVE-2026-2625

Reported-by: Yashashree Shivaji Gund